### PR TITLE
Implement address scanning on initial load

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,7 +88,7 @@ export default function Home() {
         }
 
         setIsShowDemo(window.location.hostname !== 'kasvault.io');
-    });
+    }, []);
 
     const smallStyles = width <= 48 * 16 ? { fontSize: '1rem' } : {};
 

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import styles from './page.module.css';
-import { getAddress, fetchAddressDetails, initTransport, getAddressBalance } from '@/lib/ledger';
+import { getAddress, fetchAddressDetails, initTransport, fetchAddressBalance } from '@/lib/ledger';
 import { useState, useEffect } from 'react';
 import { Stack, Tabs, Breadcrumbs, Anchor, Button, Center } from '@mantine/core';
 import Header from '../../components/header';
@@ -97,7 +97,7 @@ async function loadOrScanAddressBatch(bip32, callback, callbackSetRawAddresses, 
                     promises.push(
                         new Promise(async (resolve, reject) => {
                             try {
-                                const balanceData = await getAddressBalance(address);
+                                const balanceData = await fetchAddressBalance(address);
 
                                 resolve({ balanceData, addressIndex });
                             } catch (e) {

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -79,22 +79,32 @@ async function loadOrScanAddressBatch(bip32, callback, callbackSetRawAddresses, 
 
                 // scan for the next batch of 5 addresses to see which is the latest one with that had funds
                 const batchSize = 5;
-                console.info(`Scanning receive address range ${scanIndexStart} - ${scanIndexStart + batchSize - 1}`);
+                console.info(
+                    `Scanning receive address range ${scanIndexStart} - ${
+                        scanIndexStart + batchSize - 1
+                    }`,
+                );
 
                 let promises = [];
-                for (let addressIndex = scanIndexStart; addressIndex < scanIndexStart + batchSize; addressIndex++) {
+                for (
+                    let addressIndex = scanIndexStart;
+                    addressIndex < scanIndexStart + batchSize;
+                    addressIndex++
+                ) {
                     const addressType = 0; // Receive
                     const address = bip32.getAddress(addressType, addressIndex);
 
-                    promises.push(new Promise(async (resolve, reject) => {
-                        try {
-                            const balanceData = await getAddressBalance(address);
+                    promises.push(
+                        new Promise(async (resolve, reject) => {
+                            try {
+                                const balanceData = await getAddressBalance(address);
 
-                            resolve({balanceData, addressIndex});
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }));
+                                resolve({ balanceData, addressIndex });
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }),
+                    );
                 }
 
                 try {
@@ -113,7 +123,8 @@ async function loadOrScanAddressBatch(bip32, callback, callbackSetRawAddresses, 
                     notifications.hide(notifId);
                     notifications.show({
                         title: 'Error',
-                        message: 'Failed to scan for addresses with balance. Refresh the page to retry.',
+                        message:
+                            'Failed to scan for addresses with balance. Refresh the page to retry.',
                         autoClose: false,
                         color: 'red',
                     });
@@ -129,7 +140,9 @@ async function loadOrScanAddressBatch(bip32, callback, callbackSetRawAddresses, 
             notifications.hide(notifId);
             notifications.show({
                 title: 'Initial scan complete',
-                message: `${addressesWithBalancesFound} ${addressesWithBalancesFound <= 1 ? 'address' : 'addresses'} with balance found`,
+                message: `${addressesWithBalancesFound} ${
+                    addressesWithBalancesFound <= 1 ? 'address' : 'addresses'
+                } with balance found`,
             });
         }
 
@@ -405,14 +418,11 @@ export default function Dashboard() {
         }
 
         if (deviceType === 'usb') {
-            loadOrScanAddressBatch(
-                bip32base,
-                setAddresses,
-                setRawAddresses,
-                userSettings,
-            ).finally(() => {
-                setEnableGenerate(true);
-            });
+            loadOrScanAddressBatch(bip32base, setAddresses, setRawAddresses, userSettings).finally(
+                () => {
+                    setEnableGenerate(true);
+                },
+            );
         } else if (deviceType === 'demo') {
             userSettings.setSetting('lastReceiveIndex', 0);
             demoLoadAddress(

--- a/lib/ledger.ts
+++ b/lib/ledger.ts
@@ -129,7 +129,7 @@ export type UtxoInfo = {
     amount: number;
 };
 
-export async function getAddressBalance(address) {
+export async function fetchAddressBalance(address) {
     const { data: balanceData } = await axios.get(
         `https://api.kaspa.org/addresses/${address}/balance`,
     );
@@ -138,7 +138,7 @@ export async function getAddressBalance(address) {
 }
 
 export async function fetchAddressDetails(address, derivationPath) {
-    const balanceData = await getAddressBalance(address);
+    const balanceData = await fetchAddressBalance(address);
     const { data: utxoData } = await axios.get(`https://api.kaspa.org/addresses/${address}/utxos`);
 
     // UTXOs sorted by decreasing amount. Using the biggest UTXOs first minimizes number of utxos needed

--- a/lib/ledger.ts
+++ b/lib/ledger.ts
@@ -129,10 +129,16 @@ export type UtxoInfo = {
     amount: number;
 };
 
-export async function fetchAddressDetails(address, derivationPath) {
+export async function getAddressBalance(address) {
     const { data: balanceData } = await axios.get(
         `https://api.kaspa.org/addresses/${address}/balance`,
     );
+
+    return balanceData;
+}
+
+export async function fetchAddressDetails(address, derivationPath) {
+    const balanceData = await getAddressBalance(address);
     const { data: utxoData } = await axios.get(`https://api.kaspa.org/addresses/${address}/utxos`);
 
     // UTXOs sorted by decreasing amount. Using the biggest UTXOs first minimizes number of utxos needed

--- a/lib/settings-store.ts
+++ b/lib/settings-store.ts
@@ -11,7 +11,7 @@ class SettingsStore {
         } else {
             this.settings = {
                 receiveAddresses: {},
-                lastReceiveIndex: 0,
+                lastReceiveIndex: -1,
                 changeAddresses: {},
                 lastChangeIndex: -1,
                 version: 0,


### PR DESCRIPTION
On first load on a new device, check for addresses in batches of 5 to look for addresses that have a balance. The search continues until we find a batch where all the addresses in it have no balance.

Fixes #8 

Preview URL: https://kasvault-git-init-scan-coderofstuffs-projects.vercel.app/

https://github.com/user-attachments/assets/b63d5574-243e-49e4-90b9-fc2d3da1e3eb

